### PR TITLE
index.html: fixed box for Richards benchmark

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@ body {
             <a href="http://developers.google.com/octane/benchmark#richards"
               target="_blank" style="float:left; color:#994520">Richards</a>
    
-            <span class="p-result" id="Result-Richards" style="float:right">...</span>
+            <p class="p-result" id="Result-Richards" style="float:right">...</p>
             <span class="label-simple"
               style="position: absolute; bottom: 3px; left: 3px;">Core
               language features</span>


### PR DESCRIPTION
All other benchmark boxes report their results in 'p' tag. Richards was
reported in 'span'. This patch aligns tag naming convention for all
boxes to 'p'.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>