### PR TITLE
Fix memory leak in pdfjs.js.

### DIFF
--- a/pdfjs.js
+++ b/pdfjs.js
@@ -65,6 +65,7 @@ function runPdfJS() {
 
   // Wait for everything to complete.
   PdfJS_window.flushTimeouts();
+  canvas_logs.length = 0;
 }
 
 function tearDownPdfJS() {

--- a/pdfjs.js
+++ b/pdfjs.js
@@ -43,6 +43,7 @@ function setupPdfJS() {
 }
 
 function runPdfJS() {
+  canvas_logs.length = 0;
   PDFJS.getDocument(pdf_file).then(function(pdf) {
     var canvas = PdfJS_window.document.getElementById('canvas');
     var context = canvas.getContext('2d');
@@ -65,7 +66,6 @@ function runPdfJS() {
 
   // Wait for everything to complete.
   PdfJS_window.flushTimeouts();
-  canvas_logs.length = 0;
 }
 
 function tearDownPdfJS() {


### PR DESCRIPTION
A large amount of data is pushed into the global variable `canvas_logs` which isn't cleared in runPdfJS. On each iteration the list grows, eventually significantly so.

On a Linux machine with a recent-ish V8, it manages 2777 iterations before an allocation fails (at which point it's allocated over 2GiB of virtual memory, and used about 1.4Gib) and V8 crashes (`Fatal error in CALL_AND_RETRY_LAST`). From iteration ~800 onwards, things start slowing down gradually; at iteration ~1700, they start slowing down considerably; and at iteration ~2750, performance falls off a cliff; presumably as the GC comes under more and more strain. Here's a graph showing this (x axis=iteration number; y axis=time):

![img1](https://cloud.githubusercontent.com/assets/20318/19020806/9b9c85ae-88aa-11e6-98fa-2d1243662091.png)

It can be a little hard to see what's going on because the last iteration or two are so slow and, in a sense, distort the rest of the graph. If I chop off the last 80 iterations, one can still see that odd things are happening:

![img2](https://cloud.githubusercontent.com/assets/20318/19020808/9fe12b74-88aa-11e6-9e0b-42746f54e0e5.png)

By emptying `canvas_logs` at the end of each benchmark run, we make the
benchmark's performance more consistent. With this patch I can happily run this
benchmark in constant memory for 10000 iterations, with no discernible change in
iteration time over that.
